### PR TITLE
Use chain instead of assuming list datatypes

### DIFF
--- a/manifesto/manifest.py
+++ b/manifesto/manifest.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from bencode import bencode
+import itertools
 
 from django.utils.hashcompat import sha_constructor
 
@@ -15,5 +16,5 @@ class Manifest(object):
         return []
 
     def revision(self):
-        revision = self.fallback() + self.network() + self.cache()
+        revision = list(itertools.chain(self.fallback(), self.network(), self.cache()))
         return sha_constructor(bencode(revision)).hexdigest()[:7]


### PR DESCRIPTION
cache will be a generator on the second request, which causes:

``` python
TypeError at /manifest.appcache
can only concatenate list (not "generator") to list

... environ/lib/python2.7/site-packages/manifesto/manifest.py in revision, line 21
```
