### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To install it :
 
 
 For documentation, usage, and examples, see :
-http://manifesto.readthedocs.org/
+https://manifesto.readthedocs.io/
 
 To suggest a feature or report a bug :
 https://github.com/cyberdelia/manifesto/issues


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.